### PR TITLE
[BFF-1] Signin mutation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+.env.local

--- a/index.js
+++ b/index.js
@@ -1,29 +1,106 @@
 import { ApolloServer } from '@apollo/server';
 import { startStandaloneServer } from '@apollo/server/standalone';
+import axios from 'axios';
+import cors from 'cors';
 
-// 1. Define your schema
+const API_URL = process.env.API_URL || 'http://localhost:3000/api/v1';
+
 const typeDefs = `#graphql
+  type User {
+    id: ID!
+    name: String
+    email: String!
+    avatarUrl: String
+  }
+
   type Query {
-    hello: String
+    # Fetches the currently logged-in user
+    me: User
+  }
+
+  type Mutation {
+    signInWithGoogle(googleToken: String!): User
   }
 `;
 
-// 2. Define your resolvers
 const resolvers = {
   Query: {
-    hello: () => 'Hello from the Bluedit BFF!',
+    me: async (_, __, context) => {
+      // 1. Get the session token from the browser's cookie
+      const token = context.req.headers.cookie?.split('session_token=')[1];
+
+      if (!token) {
+        return null; // No user is logged in
+      }
+
+      try {
+        // 2. Send the token to the API to get the user's data
+        //    (We will need to build this protected endpoint in Rails next)
+        const response = await axios.get(`${API_URL}/auth/me`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+
+        const user = response.data;
+
+        // 3. Return the user data to the frontend
+        return {
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          avatarUrl: user.avatar_url,
+        };
+      } catch (error) {
+        // Token is invalid or expired
+        console.error("Session validation failed:", error);
+        return null;
+      }
+    },
+  },
+  Mutation: {
+    signInWithGoogle: async (_, { googleToken }, context) => {
+      console.log('BFF: Received signInWithGoogle request with token length:', googleToken?.length);
+      try {
+        console.log('BFF: Making request to Rails API at:', `${API_URL}/auth/google`);
+        const response = await axios.post(`${API_URL}/auth/google`, {
+          google_token: googleToken,
+        });
+
+        console.log('BFF: Rails API response:', response.data);
+        const { token, user } = response.data;
+
+        context.res.setHeader(
+          'Set-Cookie',
+          `session_token=${token}; HttpOnly; Path=/; SameSite=Strict; Max-Age=2592000` // 30 days
+        );
+
+        return {
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          avatarUrl: user.avatar_url,
+        };
+      } catch (error) {
+        console.error('BFF: Error calling Rails API:', error.response?.data || error.message);
+        throw new Error(`Failed to authenticate with backend API: ${error.response?.data?.error || error.message}`);
+      }
+    },
   },
 };
 
-// 3. Create the server instance
 const server = new ApolloServer({
   typeDefs,
   resolvers,
 });
 
-// 4. Start the server
 const { url } = await startStandaloneServer(server, {
+  context: async ({ req, res }) => ({ req, res }),
   listen: { port: 4000 },
+  middleware: [
+    cors({
+      origin: 'http://localhost:3001',
+      credentials: true,
+    }),
+  ],
 });
 
 console.log(`🚀 BFF Server ready at: ${url}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "@apollo/server": "^5.0.0",
+        "axios": "^1.11.0",
+        "cors": "^2.8.5",
         "graphql": "^16.11.0"
       }
     },
@@ -402,6 +404,12 @@
         "retry": "0.13.1"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -415,6 +423,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/body-parser": {
@@ -493,6 +512,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/content-type": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
@@ -559,6 +590,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -638,6 +678,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -661,6 +716,26 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -674,6 +749,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/function-bind": {
@@ -1008,6 +1120,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.14.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   "homepage": "https://github.com/jonathanlie/bluedit-bff#readme",
   "dependencies": {
     "@apollo/server": "^5.0.0",
+    "axios": "^1.11.0",
+    "cors": "^2.8.5",
     "graphql": "^16.11.0"
   }
 }


### PR DESCRIPTION
Added GraphQL mutation that accepts a Google ID token from the frontend. This mutation will call the new API endpoint, receive the JWT session token, and set it as a secure, httpOnly cookie in the response to the client.

- signInWithGoogle(googleToken: String!): User mutation is added to the GraphQL schema.
- The resolver for this mutation calls the `bluedit-api`'s POST /api/v1/auth/google endpoint.
- On a successful response from the API, the BFF sets a secure, httpOnly cookie containing the session JWT.
- The mutation returns the user's data.